### PR TITLE
Fix bad file content upon uploading to s3

### DIFF
--- a/default.config.json
+++ b/default.config.json
@@ -1,3 +1,3 @@
 {
-    "url": "http://localhost:3000/"
+    "url": "https://api-default.scp-staging.biomage.net/"
 }

--- a/src/connection.py
+++ b/src/connection.py
@@ -1,14 +1,10 @@
 from utils import load_json
 import boto3
 import requests
-
 import datetime
 import hashlib
 import requests
-
 import datetime
-
-from sample_file import SampleFile
 from sample import Sample
 import re
 
@@ -84,11 +80,13 @@ class Connection:
         url = 'v2/experiments/{}/samples/{}'.format(experiment_id, sample.uuid())
         self.__fetch_api(url, sample.to_json())
 
+        print('Created sample {} - {}'.format(sample.name(), sample.uuid()))
+
         for sample_file in sample.get_sample_files():
             s3url_raw = self.__create_sample_file(experiment_id, sample.uuid(), sample_file)
             s3url = re.search(r"b\'\"(.*)\"\'", str(s3url_raw)).group(1)
-            
-            print('Uploading {}...'.format(sample_file.name()))
+
+            print('Uploading {} - {}...'.format(sample_file.name(), sample_file.uuid()))
             sample_file.upload_to_S3(s3url)
             self.__notify_upload(experiment_id, sample.uuid(), sample_file.type())
             print('Uploaded {}...'.format(sample_file.name()))

--- a/src/sample.py
+++ b/src/sample.py
@@ -16,6 +16,9 @@ class Sample:
             'sampleTechnology': '10x'
         }
 
+    def name(self):
+        return self.__name
+
     def uuid(self):
         return self.__uuid
 

--- a/src/sample_file.py
+++ b/src/sample_file.py
@@ -20,6 +20,9 @@ class SampleFile:
     def name(self):
         return self.__path.split('/')[-1]
 
+    def uuid(self):
+        return self.__uuid
+
     def folder(self):
         return self.__path.split('/')[-2]
 
@@ -68,6 +71,10 @@ class SampleFile:
         if not self.__is_compressed():
             self.__compress()
 
-        files = { self.name() : (open(self.__path, 'rb')) }
+        # files = { self.name() : (open(self.__path, 'rb')) }
         headers = { 'Content-type': 'application/octet-stream' }
-        response = requests.put(signed_url, headers = headers, files = files)
+        # response = requests.put(signed_url, headers = headers, files = files)
+        with open(self.__path, 'rb') as file:
+            response = requests.put(signed_url, headers = headers, data = file.read())
+
+        print(response.content)


### PR DESCRIPTION
Python request used for uploading the file added addtional information content to the gzipped file:
`Content-Disposition: form-data; name="file"; filename="my_test3.txt"`

This broke the pipeline when the file had to be uncompressed.